### PR TITLE
updated annot arguments for cellxgene v 0.15 & added option for backed mode.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -67,6 +67,8 @@ Optional environment variables:
 * `GATEWAY_PORT` - local port that the gateway should bind to, defaults to 5005
 * `GATEWAY_EXTRA_SCRIPTS` - JSON array of script paths, will be embedded into each page and forwarded with `--scripts` to cellxgene server
 * `GATEWAY_ENABLE_UPLOAD` - Set to `true` or `1` to enable HTTP uploads. This is not recommended for a public server.
+* `GATEWAY_ENABLE_ANNOTATIONS` - Set to `true` or to `1` to enable cellxgene annotations. 
+* `GATEWAY_ENABLE_BACKED_MODE` - Set to `true` or to `1` to load AnnData in file-backed mode. This saves memory and speeds up launch time but may reduce overall performance.  
 
 The defaults should be fine if you set up a venv and cellxgene_data folder as above.
 

--- a/cellxgene_gateway/env.py
+++ b/cellxgene_gateway/env.py
@@ -21,6 +21,7 @@ extra_scripts = os.environ.get("GATEWAY_EXTRA_SCRIPTS")
 ttl = os.environ.get("GATEWAY_TTL")
 enable_upload = os.environ.get("GATEWAY_ENABLE_UPLOAD", "").lower() in ['true', '1']
 enable_annotations = os.environ.get("GATEWAY_ENABLE_ANNOTATIONS", "").lower() in ['true', '1']
+enable_backed_mode = os.environ.get("GATEWAY_ENABLE_BACKED_MODE", "").lower() in ['true', '1']
 
 env_vars = {
     "CELLXGENE_LOCATION": cellxgene_location,
@@ -36,6 +37,7 @@ optional_env_vars = {
     "GATEWAY_TTL": ttl,
     "GATEWAY_ENABLE_UPLOAD": enable_upload,
     "GATEWAY_ENABLE_ANNOTATIONS": enable_annotations,
+    "GATEWAY_ENABLE_BACKED_MODE": enable_backed_mode,
 }
 
 def validate():

--- a/cellxgene_gateway/subprocess_backend.py
+++ b/cellxgene_gateway/subprocess_backend.py
@@ -11,10 +11,11 @@ import logging
 import subprocess
 
 from flask_api import status
-from cellxgene_gateway.env import enable_annotations
+from cellxgene_gateway.env import enable_annotations, enable_backed_mode
 from cellxgene_gateway.process_exception import ProcessException
 from cellxgene_gateway.dir_util import make_annotations
 from cellxgene_gateway.path_util import get_file_path, get_annotation_file_path
+
 
 class SubprocessBackend:
     def __init__(self):
@@ -22,19 +23,20 @@ class SubprocessBackend:
 
     def create_cmd(self, cellxgene_loc, file_path, port, scripts, annotation_file_path):
         if enable_annotations and not annotation_file_path is None:
-            annotation_args_prefix = " --experimental-annotations"
             if annotation_file_path == "":
-                annotation_args = f"{annotation_args_prefix} --experimental-annotations-output-dir {make_annotations(file_path)}"
+                extra_args = f" --annotations-dir {make_annotations(file_path)}"
             else:
-                annotation_args = f"{annotation_args_prefix} --experimental-annotations-file {annotation_file_path}"
+                extra_args = f" --annotations-file {annotation_file_path}"
         else:
-            annotation_args = ""
+            extra_args = " --disable-annotations"
+        if enable_backed_mode:
+            extra_args += " --backed"
         cmd = (
             f"yes | {cellxgene_loc} launch {file_path}"
             + " --port "
             + str(port)
             + " --host 127.0.0.1"
-            + annotation_args
+            + extra_args
         )
 
         for s in scripts:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cellxgene==0.14.1
+cellxgene>=0.15
 flask
 flask_api
 psutil


### PR DESCRIPTION
This PR updates cellxgene to use the latest release from cellxgene in which annotations are enabled by default. 

It also adds the option to load the data in file-backed mode which significantly reduces loading time as the data is not fully loaded into memory. 

**NOTE**: I could not fully test the annotation mode as I did not find the way to specify the `annotation_file` 