### PR TITLE
Make cellxgene-gateway work behind a reverse proxy

### DIFF
--- a/cellxgene_gateway/cache_entry.py
+++ b/cellxgene_gateway/cache_entry.py
@@ -8,6 +8,8 @@
 # the specific language governing permissions and limitations under the License.
 import datetime
 import logging
+from flask.helpers import url_for
+from flask.wrappers import Response
 
 import psutil
 from enum import Enum
@@ -120,7 +122,7 @@ class CacheEntry:
         return gateway_content
 
     def gateway_basepath(self):
-        return f"{env.external_protocol}://{env.external_host}/view/{self.key.pathpart}/"
+        return url_for("do_view", path=self.key.pathpart) + "/"
 
     def cellxgene_basepath(self):
         return f"http://127.0.0.1:{self.port}"
@@ -130,7 +132,7 @@ class CacheEntry:
         subpath = path[len(self.key.pathpart) :]  # noqa: E203
 
         if len(subpath) == 0:
-            r = make_response(f"Redirect to {gateway_basepath}\n", 301)
+            r = make_response(f"Redirect to {gateway_basepath}\n", 302)
             r.headers["location"] = gateway_basepath + querystring()
             return r
         elif self.status == CacheEntryStatus.loading:

--- a/cellxgene_gateway/filecrawl.py
+++ b/cellxgene_gateway/filecrawl.py
@@ -89,7 +89,7 @@ def render_entries(entries):
 
 
 def get_url(entry):
-    return url_for("do_view", entry)
+    return url_for("do_view", path=entry["path"])
 
 
 def get_class(entry):

--- a/cellxgene_gateway/filecrawl.py
+++ b/cellxgene_gateway/filecrawl.py
@@ -45,10 +45,13 @@ def recurse_dir(path):
                     "name": x[:-13]
                     if (len(x) > 13 and x[-13] in ["-", "_"])
                     else (x[:-4] if x.endswith(".csv") else x),
-                    "path": os.path.join(full_path, x).replace(env.cellxgene_data, ""),
+                    "path": os.path.join(full_path, x).replace(
+                        env.cellxgene_data, ""
+                    ),
                 }
                 for x in sorted(os.listdir(full_path))
-                if x.endswith(".csv") and os.path.isfile(os.path.join(full_path, x))
+                if x.endswith(".csv")
+                and os.path.isfile(os.path.join(full_path, x))
             ]
         return [
             {
@@ -89,7 +92,7 @@ def render_entries(entries):
 
 
 def get_url(entry):
-    return url_for("do_view", path=entry["path"])
+    return url_for("do_view", path=entry["path"].lstrip("/"))
 
 
 def get_class(entry):

--- a/cellxgene_gateway/filecrawl.py
+++ b/cellxgene_gateway/filecrawl.py
@@ -14,6 +14,7 @@ from cellxgene_gateway.dir_util import (
     make_annotations,
     annotations_suffix,
 )
+from flask import url_for
 
 
 def recurse_dir(path):
@@ -44,13 +45,10 @@ def recurse_dir(path):
                     "name": x[:-13]
                     if (len(x) > 13 and x[-13] in ["-", "_"])
                     else (x[:-4] if x.endswith(".csv") else x),
-                    "path": os.path.join(full_path, x).replace(
-                        env.cellxgene_data, ""
-                    ),
+                    "path": os.path.join(full_path, x).replace(env.cellxgene_data, ""),
                 }
                 for x in sorted(os.listdir(full_path))
-                if x.endswith(".csv")
-                and os.path.isfile(os.path.join(full_path, x))
+                if x.endswith(".csv") and os.path.isfile(os.path.join(full_path, x))
             ]
         return [
             {
@@ -91,7 +89,7 @@ def render_entries(entries):
 
 
 def get_url(entry):
-    return f"/view/{ entry['path'].lstrip('/') }/"
+    return url_for("do_view", entry)
 
 
 def get_class(entry):

--- a/cellxgene_gateway/templates/cellxgene_error.html
+++ b/cellxgene_gateway/templates/cellxgene_error.html
@@ -28,11 +28,11 @@
           
      <h4>{{ message }}</h4>
 
-     <a href="/filecrawl.html">
+     <a href="{{ url_for('filecrawl') }}">
           Please click here to be redirected to the file directory.
      </a>
      <br>
-     <a href="/">
+     <a href="{{ url_for('index') }}">
           Please click here to return to the homepage.
      </a>
      </div>

--- a/cellxgene_gateway/templates/filecrawl.html
+++ b/cellxgene_gateway/templates/filecrawl.html
@@ -36,10 +36,10 @@
           Navigation:
      <ul>
      {% if path %}
-     <li><a href="/filecrawl.html">top level</a></li>
+     <li><a href="{{ url_for('filecrawl') }}">top level</a></li>
      {% else %}
      {% endif %}
-     <li><a href="/">homepage</a></li>
+     <li><a href="{{ url_for('index') }}">homepage</a></li>
      </ul>
      </p>
      <script>

--- a/cellxgene_gateway/templates/index.html
+++ b/cellxgene_gateway/templates/index.html
@@ -35,12 +35,12 @@
 		Links:	
 	</h1>
 	<div class="list-group" style="width:50%;padding-left:65px">
-	  <a href="/filecrawl.html" class="list-group-item list-group-item-action">
+	  <a href="{{ url_for('filecrawl') }}" class="list-group-item list-group-item-action">
 		  <u>File Crawler: Allows you to view all uploaded data.</u></a>
 		  
 	</div>
 	<div class="list-group" style="width:50%;padding-left:65px">
-		<a href="/cache_status" class="list-group-item list-group-item-action">
+		<a href="{{ url_for('do_GET_status') }}" class="list-group-item list-group-item-action">
 			<u>Cache Status: view status of launched cellxgene servers.</u></a>
 	</div>
 	

--- a/cellxgene_gateway/templates/loading.html
+++ b/cellxgene_gateway/templates/loading.html
@@ -35,11 +35,11 @@
           The page will refresh shortly.
      </p>
 
-     <a href="/filecrawl.html">
+     <a href="{{ url_for('filecrawl') }}">
           Please click here to be redirected to the file directory.
      </a>
      <br>
-     <a href="/">
+     <a href="{{ url_for('index') }}">
           Please click here to return to the homepage.
      </a>
      </div>

--- a/cellxgene_gateway/templates/process_error.html
+++ b/cellxgene_gateway/templates/process_error.html
@@ -39,10 +39,10 @@
           <li><a href="{{url_for('do_relaunch', path=dataset)}}">
                     Attempt to relaunch the cellxgene server.
                </a></li>
-          <li><a href="/filecrawl.html">
+          <li><a href="{{ url_for('filecrawl') }}">
                Return to the file directory.
           </a></li>
-          <li><a href="/">
+          <li><a href="{{ url_for('index') }}">
                Return to the homepage.
           </a></li>
      </ul>


### PR DESCRIPTION
I couldn't make cellxgene_gateway work properly behind a reverse proxy that doesn't point to the root path, e.g. `http://myserver.com/cellxgene_gateway`. 

This PR solves this by
 * switching to consistent use of `url_for` everywhere
 * applying the `ProxyFix` class. 

Closes #16. 