### PR TITLE
Force reload of s3 file structure on every request

### DIFF
--- a/cellxgene_gateway/items/s3/s3item_source.py
+++ b/cellxgene_gateway/items/s3/s3item_source.py
@@ -28,7 +28,7 @@ class S3ItemSource(ItemSource):
         annotation_file_suffix=".csv",
     ):
         self._name = name
-        self.s3 = s3fs.S3FileSystem()
+        self.s3 = s3fs.S3FileSystem(use_listings_cache=False)
         if bucket.startswith("s3://"):
             raise Exception(
                 f"Bucket name should not include s3:// prefix, got {bucket}"

--- a/cellxgene_gateway/items/s3/s3item_source.py
+++ b/cellxgene_gateway/items/s3/s3item_source.py
@@ -75,7 +75,7 @@ class S3ItemSource(ItemSource):
 
         s3key_map = dict(
             (self.remove_bucket(filepath), "s3://" + filepath)
-            for filepath in sorted(self.s3.ls(url))
+            for filepath in sorted(self.s3.ls(url, refresh=True))
         )
 
         def is_annotation_dir(dir_s3key):


### PR DESCRIPTION
This prevents from reflecting wrong structure and allows simple incorporation of newly uploaded datasets without need to restart the server