### PR TITLE
add basic prometheus metrics with prometheus_flask_exporter

### DIFF
--- a/cellxgene_gateway/gateway.py
+++ b/cellxgene_gateway/gateway.py
@@ -23,6 +23,7 @@ from flask import (
     url_for,
 )
 from werkzeug.middleware.proxy_fix import ProxyFix
+from prometheus_flask_exporter import PrometheusMetrics
 
 from cellxgene_gateway import env, flask_util
 from cellxgene_gateway.backend_cache import BackendCache
@@ -34,8 +35,12 @@ from cellxgene_gateway.filecrawl import render_item_source
 from cellxgene_gateway.process_exception import ProcessException
 from cellxgene_gateway.prune_process_cache import PruneProcessCache
 from cellxgene_gateway.util import current_time_stamp
+from cellxgene_gateway import __version__
 
 app = Flask(__name__)
+
+metrics = PrometheusMetrics(app)
+metrics.info('app_info', 'Application info', version=__version__)
 
 item_sources = []
 default_item_source = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask-api
 werkzeug
 psutil
 requests
+prometheus-flask-exporter


### PR DESCRIPTION
I have a need to monitor the gateway with our existing prometheus infrastructure, this PR just adds generic monitoring for flask, which will work for basic path metrics and up/down monitoring.  I plan on adding more useful metrics (cache status and usage, for example) but wanted to gauge interest with a PR early.  