### PR TITLE
Save gene sets without cell annotations

### DIFF
--- a/cellxgene_gateway/items/file/fileitem_source.py
+++ b/cellxgene_gateway/items/file/fileitem_source.py
@@ -24,21 +24,21 @@ class FileItemSource(ItemSource):
         h5ad_suffix=dir_util.h5ad_suffix,
         annotation_dir_suffix=dir_util.annotations_suffix,
         annotation_file_suffix=".csv",
+        gene_set_file_suffix="_gene_sets.csv",
     ):
         self._name = name
         self.base_path = base_path
         self.h5ad_suffix = h5ad_suffix
         self.annotation_dir_suffix = annotation_dir_suffix
         self.annotation_file_suffix = annotation_file_suffix
+        self.gene_set_file_suffix = gene_set_file_suffix
 
     @property
     def name(self):
         return self._name or f"Files:{self.base_path}"
 
     def is_gene_set(self, path: str) -> bool:
-        return ("_gene_sets" in path or "-gene-sets" in path) and path.endswith(
-            self.annotation_file_suffix
-        )
+        return path.endswith(self.gene_set_file_suffix)
 
     def is_h5ad_file(self, path: str) -> bool:
         return path.endswith(self.h5ad_suffix) and os.path.isfile(path)
@@ -186,12 +186,24 @@ class FileItemSource(ItemSource):
         annotations_subpath = self.get_annotations_subpath(item)
         annotations_fullpath = self.full_path(annotations_subpath)
         if os.path.isdir(annotations_fullpath):
-            return [
+            sorted_files = sorted(os.listdir(annotations_fullpath))
+            annotation_files = [
                 self.make_fileitem_from_path(annotation, annotations_subpath, True)
-                for annotation in sorted(os.listdir(annotations_fullpath))
+                for annotation in sorted_files
                 if annotation.endswith(self.annotation_file_suffix)
                 and not self.is_gene_set(annotation)
                 and os.path.isfile(os.path.join(annotations_fullpath, annotation))
             ]
+
+            # Catch gene sets without accompanying [annotations].csv
+            gene_sets_files = [
+                self.make_fileitem_from_path(annotation[:-len(self.gene_set_file_suffix)] + ".csv", annotations_subpath, True)
+                for annotation in sorted_files
+                if self.is_gene_set(annotation)
+                and annotation[:-len(self.gene_set_file_suffix)] not in [a.name for a in annotation_files]
+                and os.path.isfile(os.path.join(annotations_fullpath, annotation))
+            ]
+
+            return sorted(annotation_files + gene_sets_files, key = lambda x: x.name)
         else:
             return None

--- a/cellxgene_gateway/items/file/fileitem_source.py
+++ b/cellxgene_gateway/items/file/fileitem_source.py
@@ -197,13 +197,18 @@ class FileItemSource(ItemSource):
 
             # Catch gene sets without accompanying [annotations].csv
             gene_sets_files = [
-                self.make_fileitem_from_path(annotation[:-len(self.gene_set_file_suffix)] + ".csv", annotations_subpath, True)
+                self.make_fileitem_from_path(
+                    annotation[: -len(self.gene_set_file_suffix)] + ".csv",
+                    annotations_subpath,
+                    True,
+                )
                 for annotation in sorted_files
                 if self.is_gene_set(annotation)
-                and annotation[:-len(self.gene_set_file_suffix)] not in [a.name for a in annotation_files]
+                and annotation[: -len(self.gene_set_file_suffix)]
+                not in [a.name for a in annotation_files]
                 and os.path.isfile(os.path.join(annotations_fullpath, annotation))
             ]
 
-            return sorted(annotation_files + gene_sets_files, key = lambda x: x.name)
+            return sorted(annotation_files + gene_sets_files, key=lambda x: x.name)
         else:
             return None


### PR DESCRIPTION
This fixes a bug whereby new gene sets csv files created without accompanying cell-level annotations could not be detected by the filecrawler. Previously, the filecrawler only displayed csv files corresponding to cell-level annotations. This meant that if the user created a new gene set but no cell-level annotations then, whilst the gene-set csv would be saved, they could not be loaded from filecrawler.

Note; this commit also changes the behaviour when checking whether a file is a gene set. It now checks whether the file extension is `self.gene_set_file_suffix` (by default, `_gene_sets.csv`). This means that patterns such as `foo_gene_sets_bar.csv` will no longer count as a gene_sets file. I made this change for convenience here, but obviously please revert if you are worried that it will break things - it just seemed cleaner this way.